### PR TITLE
Add Accounts

### DIFF
--- a/microservices/templates/NOTES.txt
+++ b/microservices/templates/NOTES.txt
@@ -1,6 +1,8 @@
 Deployed!
 - Database: https://database.{{ .Values.ingress.domain }}
-- Inventory: {{ .Values.versions.inventory | default "latest" }} https://inventory.{{ .Values.ingress.domain }}
+{{- range $name, $settings := .Values.apps -}}
+- {{ $name }}: {{ $settings.version | default "latest" }} https://{{ $name }}.{{ $.Values.ingress.domain }}
+{{- end }}
 
 TODOs:
 - Load microservices dynamically from a list.

--- a/microservices/templates/app.yaml
+++ b/microservices/templates/app.yaml
@@ -1,34 +1,35 @@
+{{- range $name, $settings := .Values.apps -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: inventory
+  name: {{ $name }}
 spec:
   type: ClusterIP
   ports:
   - port: 80
     targetPort: 8080
   selector:
-    app: inventory
+    app: {{ $name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inventory
+  name: {{ $name }}
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: inventory
+      app: {{ $name }}
   template:
     metadata:
       labels:
-        app: inventory
+        app: {{ $name }}
     spec:
       imagePullSecrets:
         - name: image-pull
       containers:
-      - name: inventory
-        image: ghcr.io/northroad-craftworks/inventory:{{ .Values.versions.inventory | default "latest" }}
+      - name: {{ $name }}
+        image: ghcr.io/northroad-craftworks/{{ $name }}:{{ $settings.version | default "latest" }}
         ports:
         - containerPort: 8080
         env:
@@ -44,29 +45,30 @@ spec:
               name: session
               key: secret
         - name: COUCHDB_URL
-          value: http://{{ template "microservices.database-name" . }}:5984
+          value: http://{{ template "microservices.database-name" $ }}:5984
         - name: COUCHDB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "microservices.database-name" . }}
+              name: {{ template "microservices.database-name" $ }}
               key: adminUsername
         - name: COUCHDB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "microservices.database-name" . }}
+              name: {{ template "microservices.database-name" $ }}
               key: adminPassword
         - name: GOOGLE_CLIENT_ID
           valueFrom:
             secretKeyRef:
               name: google-oauth
               key: clientId
-              optional: {{ not .Values.googleOauth.enable }}
+              optional: {{ not $.Values.googleOauth.enable }}
         - name: GOOGLE_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: google-oauth
               key: clientSecret
-              optional: {{ not .Values.googleOauth.enable }}
+              optional: {{ not $.Values.googleOauth.enable }}
         - name: ALLOW_ANONYMOUS
           value: 'false'
-
+---
+{{- end -}}

--- a/microservices/templates/app.yaml
+++ b/microservices/templates/app.yaml
@@ -71,4 +71,4 @@ spec:
         - name: ALLOW_ANONYMOUS
           value: 'false'
 ---
-{{- end -}}
+{{ end -}}

--- a/microservices/values.yaml
+++ b/microservices/values.yaml
@@ -1,5 +1,7 @@
 # Define the versions of each service to use.
 apps:
+  accounts:
+    version: 1.0.0
   inventory:
     version: 1.11.1
 

--- a/microservices/values.yaml
+++ b/microservices/values.yaml
@@ -1,6 +1,7 @@
 # Define the versions of each service to use.
-versions:
-  inventory: 1.11.1
+apps:
+  inventory:
+    version: 1.11.1
 
 # The ingress is configured by default.
 ingress:

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,7 +1,14 @@
 const COMMIT_ANALYZER = [
     '@semantic-release/commit-analyzer',
     {
-        preset: 'eslint'
+        preset: 'eslint',
+        releaseRules: [
+            { tag: 'Breaking', release: 'major' },
+            { tag: 'New', release: 'minor' },
+            { tag: 'Update', release: 'minor' },
+            { tag: 'Fix', release: 'patch' },
+            { tag: 'Upgrade', release: 'patch' }
+        ]
     }
 ];
 


### PR DESCRIPTION
This PR refactors the templates to create apps dynamically from a list, rather than needing each one to be defined manually. Then, it uses that new feature to add the Accounts service.